### PR TITLE
bugfix: allow checking content pinned status without timeout

### DIFF
--- a/apps/api/src/development.controller.ts
+++ b/apps/api/src/development.controller.ts
@@ -3,7 +3,7 @@ This is a controller providing some endpoints useful for development and testing
 */
 
 // eslint-disable-next-line max-classes-per-file
-import { Controller, Get, Logger, Param, Post } from '@nestjs/common';
+import { Controller, Get, Logger, NotFoundException, Param, Post } from '@nestjs/common';
 import { InjectQueue } from '@nestjs/bullmq';
 import { Queue } from 'bullmq';
 import { Job } from 'bullmq/dist/esm/classes/job';
@@ -50,14 +50,10 @@ export class DevelopmentController {
   @Get('/asset/:assetId')
   // eslint-disable-next-line consistent-return
   async getAsset(@Param('assetId') assetId: string) {
-    try {
-      return this.ipfsService.getPinned(assetId);
-    } catch (error: any) {
-      if (error.response) {
-        console.error(error.response.data);
-      }
-      throw error;
+    if (await this.ipfsService.isPinned(assetId)) {
+      return this.ipfsService.getPinned(assetId, false);
     }
+    throw new NotFoundException(`${assetId} does not exist`);
   }
 
   @Post('/dummy/announcement/:queueType/:count')

--- a/apps/api/test/app.e2e-spec.ts
+++ b/apps/api/test/app.e2e-spec.ts
@@ -815,6 +815,11 @@ describe('AppController E2E request verification!', () => {
         .expect(200)
         .expect((res) => expect(Buffer.from(res.body)).toEqual(Buffer.from(buffer)));
     }, 15000);
+
+    it('not uploaded asset should return not found', async () => {
+      const assetId = 'bafybeieva67sj7hiiywi4kxsamcc2t2y2pptni2ki6gu63azj3pkznbzna';
+      return request(app.getHttpServer()).get(`/api/dev/asset/${assetId}`).expect(404);
+    });
   });
 
   afterEach(async () => {

--- a/apps/worker/src/request_processor/request.processor.service.ts
+++ b/apps/worker/src/request_processor/request.processor.service.ts
@@ -31,7 +31,7 @@ export class RequestProcessorService extends WorkerHost {
       const pinnedAssets = assets.map((cid) => this.ipfsService.getPinned(cid));
       const pinnedResult = await Promise.all(pinnedAssets);
       // if any of assets does not exist delay the job for a future attempt
-      if (pinnedResult.some((buffer) => !buffer)) {
+      if (pinnedResult.some((buffer) => !buffer || buffer.length === 0)) {
         await this.delayJobAndIncrementAttempts(job);
       } else {
         await this.dsnpAnnouncementProcessor.collectAnnouncementAndQueue(job.data);


### PR DESCRIPTION
# Description
Currently `/api/v0/cat` IPFS endpoint gets stuck if a non-pinned cid is passed as an argument. To be able to check the status of a content without getting stuck we would need to use another endpoint like `/api/v0/pin/ls` which returns if a cid is pinned or not.

closes #32 

# verification
- `/asset/:assetId` is modified to use this new feature and e2e tests cover this functionality by calling that endpoint