### PR TITLE
Handling Errors from Blockchain

### DIFF
--- a/apps/worker/src/publisher/publishing.service.ts
+++ b/apps/worker/src/publisher/publishing.service.ts
@@ -80,7 +80,7 @@ export class PublishingService extends WorkerHost implements OnApplicationBootst
     };
     // add a delay of 1 block to allow the tx reciept to go through before checking
     const delay = 1 * SECONDS_PER_BLOCK * MILLISECONDS_PER_SECOND;
-    await this.txReceiptQueue.add(`Tx Receipt Job - ${job.id}`, job, { jobId: job.id, removeOnFail: false, removeOnComplete: 1000, delay });
+    await this.txReceiptQueue.add(job.id, job, { jobId: job.id, removeOnFail: false, removeOnComplete: 1000, delay });
   }
 
   private async checkCapacity(): Promise<void> {


### PR DESCRIPTION
## Details
- [ ]  _Check for the existence of txHash:_ this should always be there even if messages pallet failed (reason: capacity will be withdrawn as expected and low capacity related error is handled in publisher itself: read signed extensions)
- [ ]  _Check for success events:_ If capacity withdrawn found and message stored events are found then it is a complete success
- [ ] _Check for error from module (messages pallet)_ : here based on error take action like, fail the job, re-queue or anything else 