### PR TITLE
fixed nonce and transaction receipt

### DIFF
--- a/apps/worker/src/batch_announcer/batch.announcer.service.ts
+++ b/apps/worker/src/batch_announcer/batch.announcer.service.ts
@@ -43,7 +43,7 @@ export class BatchAnnouncementService extends BaseConsumer implements OnModuleDe
     try {
       const publisherJob = await this.ipfsPublisher.announce(job.data);
       // eslint-disable-next-line no-promise-executor-return
-      await this.publishQueue.add(publisherJob.id, publisherJob, { jobId: publisherJob.id, removeOnComplete: 1000 });
+      await this.publishQueue.add(publisherJob.id, publisherJob, { jobId: publisherJob.id, removeOnComplete: 1000, attempts: 3 });
       this.logger.log(`Completed job ${job.id} of type ${job.name}`);
       return job.data;
     } catch (e) {

--- a/apps/worker/src/monitor/status.monitor.module.ts
+++ b/apps/worker/src/monitor/status.monitor.module.ts
@@ -54,24 +54,12 @@ import { QueueConstants } from '../../../../libs/common/src';
       {
         name: QueueConstants.TRANSACTION_RECEIPT_QUEUE_NAME,
         defaultJobOptions: {
-          attempts: 3,
-          backoff: {
-            type: 'exponential',
-          },
           removeOnComplete: true,
           removeOnFail: false,
         },
       },
       {
         name: QueueConstants.PUBLISH_QUEUE_NAME,
-        defaultJobOptions: {
-          attempts: 1,
-          backoff: {
-            type: 'exponential',
-          },
-          removeOnComplete: true,
-          removeOnFail: false,
-        },
       },
     ),
   ],

--- a/libs/common/src/blockchain/blockchain.service.ts
+++ b/libs/common/src/blockchain/blockchain.service.ts
@@ -165,66 +165,68 @@ export class BlockchainService implements OnApplicationBootstrap, OnApplicationS
     txHash: Hash,
     blockList: bigint[],
     successEvents: [{ pallet: string; event: string }],
-  ): Promise<{ success: boolean; blockHash?: BlockHash; capacityWithDrawn?: string; error?: RegistryError }> {
-    const txReceiptPromises: Promise<{ success: boolean; blockHash?: BlockHash; capacityWithDrawn?: string; error?: RegistryError }>[] = blockList.map(async (blockNumber) => {
-      const blockHash = await this.getBlockHash(blockNumber);
-      const block = await this.getBlock(blockHash);
-      const txInfo = block.block.extrinsics.find((extrinsic) => extrinsic.hash.toString() === txHash.toString());
+  ): Promise<{ found: boolean; success: boolean; blockHash?: BlockHash; capacityWithDrawn?: string; error?: RegistryError }> {
+    const txReceiptPromises: Promise<{ found: boolean; success: boolean; blockHash?: BlockHash; capacityWithDrawn?: string; error?: RegistryError }>[] = blockList.map(
+      async (blockNumber) => {
+        const blockHash = await this.getBlockHash(blockNumber);
+        const block = await this.getBlock(blockHash);
+        const txInfo = block.block.extrinsics.find((extrinsic) => extrinsic.hash.toString() === txHash.toString());
 
-      if (!txInfo) {
-        return { success: false };
-      }
+        if (!txInfo) {
+          return { found: false, success: false };
+        }
 
-      this.logger.verbose(`Found tx ${txHash} in block ${blockNumber}`);
-      const at = await this.api.at(blockHash.toHex());
-      const eventsPromise = firstValueFrom(at.query.system.events());
+        this.logger.verbose(`Found tx ${txHash} in block ${blockNumber}`);
+        const at = await this.api.at(blockHash.toHex());
+        const eventsPromise = firstValueFrom(at.query.system.events());
 
-      let isTxSuccess = false;
-      let totalBlockCapacity: bigint = 0n;
-      let txError: RegistryError | undefined;
+        let isTxSuccess = false;
+        let totalBlockCapacity: bigint = 0n;
+        let txError: RegistryError | undefined;
 
-      try {
-        const events = await eventsPromise;
+        try {
+          const events = await eventsPromise;
 
-        events.forEach((record) => {
-          const { event } = record;
-          const eventName = event.section;
-          const { method } = event;
-          const { data } = event;
-          this.logger.debug(`Received event: ${eventName} ${method} ${data}`);
+          events.forEach((record) => {
+            const { event } = record;
+            const eventName = event.section;
+            const { method } = event;
+            const { data } = event;
+            this.logger.debug(`Received event: ${eventName} ${method} ${data}`);
 
-          // find capacity withdrawn event
-          if (eventName.search('capacity') !== -1 && method.search('Withdrawn') !== -1) {
-            // allow lowercase constructor for eslint
-            // eslint-disable-next-line new-cap
-            const currentCapacity: u128 = new u128(this.api.registry, data[1]);
-            totalBlockCapacity += currentCapacity.toBigInt();
-          }
+            // find capacity withdrawn event
+            if (eventName.search('capacity') !== -1 && method.search('Withdrawn') !== -1) {
+              // allow lowercase constructor for eslint
+              // eslint-disable-next-line new-cap
+              const currentCapacity: u128 = new u128(this.api.registry, data[1]);
+              totalBlockCapacity += currentCapacity.toBigInt();
+            }
 
-          // check custom success events
-          if (successEvents.find((successEvent) => successEvent.pallet === eventName && successEvent.event === method)) {
-            this.logger.debug(`Found success event ${eventName} ${method}`);
-            isTxSuccess = true;
-          }
+            // check custom success events
+            if (successEvents.find((successEvent) => successEvent.pallet === eventName && successEvent.event === method)) {
+              this.logger.debug(`Found success event ${eventName} ${method}`);
+              isTxSuccess = true;
+            }
 
-          // check for system extrinsic failure
-          if (eventName.search('system') !== -1 && method.search('ExtrinsicFailed') !== -1) {
-            const dispatchError = data[0] as DispatchError;
-            const moduleThatErrored = dispatchError.asModule;
-            const moduleError = dispatchError.registry.findMetaError(moduleThatErrored);
-            txError = moduleError;
-            this.logger.error(`Extrinsic failed with error: ${JSON.stringify(moduleError)}`);
-          }
-        });
-      } catch (error) {
-        this.logger.error(error);
-      }
-      this.logger.debug(`Total capacity withdrawn in block: ${totalBlockCapacity.toString()}`);
-      return { success: isTxSuccess, blockHash, capacityWithDrawn: totalBlockCapacity.toString(), error: txError };
-    });
+            // check for system extrinsic failure
+            if (eventName.search('system') !== -1 && method.search('ExtrinsicFailed') !== -1) {
+              const dispatchError = data[0] as DispatchError;
+              const moduleThatErrored = dispatchError.asModule;
+              const moduleError = dispatchError.registry.findMetaError(moduleThatErrored);
+              txError = moduleError;
+              this.logger.error(`Extrinsic failed with error: ${JSON.stringify(moduleError)}`);
+            }
+          });
+        } catch (error) {
+          this.logger.error(error);
+        }
+        this.logger.debug(`Total capacity withdrawn in block: ${totalBlockCapacity.toString()}`);
+        return { found: true, success: isTxSuccess, blockHash, capacityWithDrawn: totalBlockCapacity.toString(), error: txError };
+      },
+    );
     const results = await Promise.all(txReceiptPromises);
-    const result = results.find((receipt) => receipt.blockHash !== undefined);
+    const result = results.find((receipt) => receipt.found);
     this.logger.debug(`Found tx receipt: ${JSON.stringify(result)}`);
-    return result ?? { success: false };
+    return result ?? { found: false, success: false };
   }
 }

--- a/libs/common/src/utils/redis.ts
+++ b/libs/common/src/utils/redis.ts
@@ -7,7 +7,18 @@ export namespace RedisUtils {
    * batch Lock expire time which applies during closing operation
    */
   export const BATCH_LOCK_EXPIRE_SECONDS = 6;
-  export const CHAIN_NONCE_KEY = 'chain:nonce';
+  /**
+   * To be able to provide mostly unique nonces to submit transactions on chain we would need to check a number of
+   * temporarily locked keys on redis side and get the first available one. This number defines the number of keys
+   * we should look into before giving up
+   */
+  export const NUMBER_OF_NONCE_KEYS_TO_CHECK = 50;
+  /**
+   * Nonce keys have to get expired shortly so that if any of nonce numbers get skipped we would still have a way to
+   * submit them after expiration
+   */
+  export const NONCE_KEY_EXPIRE_SECONDS = 2;
+  const CHAIN_NONCE_KEY = 'chain:nonce';
   const ASSET_DATA_KEY_PREFIX = 'asset:data';
   const ASSET_METADATA_KEY_PREFIX = 'asset:metadata';
   const BATCH_DATA_KEY_PREFIX = 'batch:data';
@@ -32,5 +43,9 @@ export namespace RedisUtils {
 
   export function getLockKey(suffix: string) {
     return `${LOCK_KEY_PREFIX}:${suffix}`;
+  }
+
+  export function getNonceKey(suffix: string) {
+    return `${CHAIN_NONCE_KEY}:${suffix}`;
   }
 }


### PR DESCRIPTION
# Description
After running a number of load tests I found a number of issues that is fixed in this PR

# Issues fixed
- If a nonce gets skipped from chain perspective then all the nonces after that are in wait state in transaction pool on chain and never gets included in a block. This is fixed by modifying the way we are handling nonces and came of with a self-healing process that will always reset back the nonce in case this situation happens
- The transaction receipt was using the an incorrect event to check for success
- The transaction receipt retries was not working as expected

# Verification video


https://github.com/AmplicaLabs/content-publishing-service/assets/9152501/b71d2123-c03b-42d5-b8c2-9036a8c3241c

