### PR TITLE
fix(batch-worker): schema breaking changes

### DIFF
--- a/apps/worker/src/batch_announcer/batch.announcer.spec.ts
+++ b/apps/worker/src/batch_announcer/batch.announcer.spec.ts
@@ -14,7 +14,7 @@ const mockConfigService = {
 };
 
 const mockBlockchainService = {
-  getSchema: jest.fn(),
+  getSchemaPayload: jest.fn(),
 };
 
 const mockIpfsService = {
@@ -74,7 +74,7 @@ describe('BatchAnnouncer', () => {
   it('should announce a batch to IPFS', async () => {
     // Mock the necessary dependencies' behavior
     mockConfigService.getIpfsCidPlaceholder.mockReturnValue('mockIpfsUrl');
-    mockBlockchainService.getSchema.mockReturnValue({ model: Buffer.from(stringToHex(JSON.stringify(broadcast))) });
+    mockBlockchainService.getSchemaPayload.mockReturnValue(Buffer.from(stringToHex(JSON.stringify(broadcast))));
     mockIpfsService.getPinned.mockReturnValue(Buffer.from('mockContentBuffer'));
     mockIpfsService.ipfsPin.mockReturnValue({ cid: 'mockCid', size: 10, hash: 'mockHash' });
 
@@ -87,6 +87,6 @@ describe('BatchAnnouncer', () => {
     const result = await ipfsAnnouncer.announce(batchJob);
     assert(result);
     expect(mockConfigService.getIpfsCidPlaceholder).toHaveBeenCalledWith('mockCid');
-    expect(mockBlockchainService.getSchema).toHaveBeenCalledWith(123);
+    expect(mockBlockchainService.getSchemaPayload).toHaveBeenCalledWith(123);
   });
 });

--- a/apps/worker/src/batch_announcer/batch.announcer.ts
+++ b/apps/worker/src/batch_announcer/batch.announcer.ts
@@ -4,7 +4,6 @@ import { ParquetWriter } from '@dsnp/parquetjs';
 import { fromFrequencySchema } from '@dsnp/frequency-schemas/parquet';
 import { InjectRedis } from '@liaoliaots/nestjs-redis';
 import Redis from 'ioredis';
-import { PalletSchemasSchema } from '@polkadot/types/lookup';
 import { hexToString } from '@polkadot/util';
 import { RedisUtils } from '../../../../libs/common/src/utils/redis';
 import { BlockchainService } from '../../../../libs/common/src/blockchain/blockchain.service';
@@ -33,13 +32,13 @@ export class BatchAnnouncer {
     const schemaCacheKey = `schema:${schemaId}`;
     let cachedSchema: string | null = await this.cacheManager.get(schemaCacheKey);
     if (!cachedSchema) {
-      const schemaResponse = await this.blockchainService.getSchema(schemaId);
+      const schemaResponse = await this.blockchainService.getSchemaPayload(schemaId);
       cachedSchema = JSON.stringify(schemaResponse);
       await this.cacheManager.setex(schemaCacheKey, RedisUtils.STORAGE_EXPIRE_UPPER_LIMIT_SECONDS, cachedSchema);
     }
 
-    const frequencySchema: PalletSchemasSchema = JSON.parse(cachedSchema);
-    const hexString: string = Buffer.from(frequencySchema.model).toString('utf8');
+    const frequencySchemaPayload = JSON.parse(cachedSchema);
+    const hexString: string = Buffer.from(frequencySchemaPayload).toString('utf8');
     const schema = JSON.parse(hexToString(hexString));
     if (!schema) {
       throw new Error(`Unable to parse schema for schemaId ${schemaId}`);

--- a/libs/common/src/blockchain/blockchain.service.ts
+++ b/libs/common/src/blockchain/blockchain.service.ts
@@ -7,8 +7,8 @@ import { KeyringPair } from '@polkadot/keyring/types';
 import { BlockHash, BlockNumber, DispatchError, DispatchInfo, Hash, SignedBlock } from '@polkadot/types/interfaces';
 import { SubmittableExtrinsic } from '@polkadot/api/types';
 import { AnyNumber, ISubmittableResult, RegistryError } from '@polkadot/types/types';
-import { u32, Option, u128 } from '@polkadot/types';
-import { PalletCapacityCapacityDetails, PalletCapacityEpochInfo, PalletSchemasSchema } from '@polkadot/types/lookup';
+import { u32, Option, u128, Bytes } from '@polkadot/types';
+import { PalletCapacityCapacityDetails, PalletCapacityEpochInfo } from '@polkadot/types/lookup';
 import { ConfigService } from '../config/config.service';
 import { Extrinsic } from './extrinsic';
 
@@ -152,8 +152,8 @@ export class BlockchainService implements OnApplicationBootstrap, OnApplicationS
     return this.api.consts.frequencyTxPayment.maximumCapacityBatchLength.toNumber();
   }
 
-  public async getSchema(schemaId: number): Promise<PalletSchemasSchema> {
-    const schema: PalletSchemasSchema = await this.query('schemas', 'schemas', schemaId);
+  public async getSchemaPayload(schemaId: number): Promise<Bytes> {
+    const schema: Bytes = await this.query('schemas', 'schemaPayloads', schemaId);
     return schema;
   }
 


### PR DESCRIPTION
Schema changes due to limiting the size of POV created breaking changes to how schemas are accessed.

Update how schemas are queried to ensure that a schema payload is returned.

#84 