### PR TITLE
fix: use shell method in ENTRYPOINT in order to capture ENV

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,10 +21,10 @@ COPY --from=builder /usr/src/app/dist ./dist
 COPY package*.json ./
 COPY ./lua ./lua
 
-RUN npm install --only=production
+RUN npm ci --omit=dev
 
 EXPOSE 3000
 
 ENV START_PROCESS="api"
 
-ENTRYPOINT ["npm", "run", "start:${START_PROCESS}:prod"]
+ENTRYPOINT npm run start:${START_PROCESS}:prod

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   redis:
     image: redis:latest


### PR DESCRIPTION
Use the shell version of ENTRYPOINT instead of the 'exec' version so that `START_PROCESS` can be captured from the environment.