### PR TITLE
extend typed announcement with record type

### DIFF
--- a/apps/worker/src/batch_announcer/batch.announcer.ts
+++ b/apps/worker/src/batch_announcer/batch.announcer.ts
@@ -50,7 +50,7 @@ export class BatchAnnouncer {
     const writer = await ParquetWriter.openStream(parquetSchema, publishStream as any, writerOptions);
     // eslint-disable-next-line no-restricted-syntax
     for await (const announcement of announcements) {
-      await writer.appendRow(announcement as Record<string, any>);
+      await writer.appendRow(announcement);
     }
     await writer.close();
 

--- a/libs/common/src/interfaces/dsnp.ts
+++ b/libs/common/src/interfaces/dsnp.ts
@@ -61,7 +61,8 @@ interface UpdateFields {
 export type TypedAnnouncement<T extends AnnouncementType> = {
   announcementType: T;
   fromId: string;
-} & (TombstoneFields | BroadcastFields | ReplyFields | ReactionFields | ProfileFields | UpdateFields);
+} & (TombstoneFields | BroadcastFields | ReplyFields | ReactionFields | ProfileFields | UpdateFields) &
+Record<string, unknown>;
 
 /**
  * Announcement: an Announcement intended for inclusion in a batch file


### PR DESCRIPTION
From Wil!

> @saraswatpuneet I found the correct fix and it isn't in the Parquetjs side.
> 
> The TypedAnnouncement type needs to explicitly extend intersect with the Record<string, unknown>
> image

![image](https://github.com/AmplicaLabs/content-publishing-service/assets/61435908/00255f52-578d-47f2-9a1e-ba532f76abbb)
