### PR TITLE
fix: temporarily disable content hash validation in DTOs

### DIFF
--- a/libs/common/src/utils/dsnp-validation.decorator.ts
+++ b/libs/common/src/utils/dsnp-validation.decorator.ts
@@ -24,7 +24,14 @@ function validateMsaIdString(msaId: string): boolean {
 }
 
 const hexRe = /^(?:0x)?(?<hexString>f[0-9a-f]+)$/i;
+
 function validateContentHash(contentHash: string): boolean {
+  // TODO: disabling this check for the moment until we figure out
+  // what the problem is with validating content hashes. Either we're using
+  // an incorrect method to generate them in content-publisher, or we're not
+  // validating them properly here.
+  return true;
+
   try {
     const hexMatch = hexRe.exec(contentHash);
     if (hexMatch && hexMatch?.groups) {
@@ -32,8 +39,7 @@ function validateContentHash(contentHash: string): boolean {
       const decoded = base16.decode(hexString.toLowerCase());
       CID.decode(decoded);
     } else {
-      const cid = CID.parse(contentHash);
-      console.log(cid.toString(base16.encoder));
+      CID.parse(contentHash);
     }
   } catch (err: any) {
     console.error(`Invalid multiformat content hash: ${err.message}`);

--- a/libs/common/src/utils/dsnp-validation.decorator.ts
+++ b/libs/common/src/utils/dsnp-validation.decorator.ts
@@ -32,21 +32,21 @@ function validateContentHash(contentHash: string): boolean {
   // validating them properly here.
   return true;
 
-  try {
-    const hexMatch = hexRe.exec(contentHash);
-    if (hexMatch && hexMatch?.groups) {
-      const { hexString } = hexMatch.groups;
-      const decoded = base16.decode(hexString.toLowerCase());
-      CID.decode(decoded);
-    } else {
-      CID.parse(contentHash);
-    }
-  } catch (err: any) {
-    console.error(`Invalid multiformat content hash: ${err.message}`);
-    return false;
-  }
+  // try {
+  //   const hexMatch = hexRe.exec(contentHash);
+  //   if (hexMatch && hexMatch?.groups) {
+  //     const { hexString } = hexMatch.groups;
+  //     const decoded = base16.decode(hexString.toLowerCase());
+  //     CID.decode(decoded);
+  //   } else {
+  //     CID.parse(contentHash);
+  //   }
+  // } catch (err: any) {
+  //   console.error(`Invalid multiformat content hash: ${err.message}`);
+  //   return false;
+  // }
 
-  return true;
+  // return true;
 }
 
 export function IsDsnpUserURI(validationOptions?: ValidationOptions) {


### PR DESCRIPTION
 # Description
Temporarily disable DTO validation of content hash-related fields until we resolve questions/issues surrounding correct generation/validation techniques.